### PR TITLE
Added sha 256, sha348 and sha512 checksum to xml update server

### DIFF
--- a/com_swjprojects/site/models/jupdate.php
+++ b/com_swjprojects/site/models/jupdate.php
@@ -545,6 +545,9 @@ class SWJProjectsModelJUpdate extends BaseDatabaseModel
 						$downloadurl = $downloads->addChild('downloadurl', $site_root . $item->download);
 						$downloadurl->addAttribute('type', 'full');
 						$downloadurl->addAttribute('format', File::getExt($item->file));
+						$update->addChild('sha256',hash_file('sha256',$site_root . $item->download));
+						$update->addChild('sha384',hash_file('sha384',$site_root . $item->download));
+						$update->addChild('sha512',hash_file('sha512',$site_root . $item->download));
 					}
 
 					$tags = $update->addChild('tags');


### PR DESCRIPTION
**Summary of changes**
Добавлены контрольные суммы файла sha 256, sha348 и sha512 в модель jupdate.

Результат ДО: при обновлении Joomla 4 выкидывала предупреждение о том, что не найдена контрольная сумма в сервере обновлений.
Результат ПОСЛЕ: предупреждение не показывается.