### PR TITLE
Fixes for php version 8.1 - Deprecated

### DIFF
--- a/com_swjprojects/admin/models/key.php
+++ b/com_swjprojects/admin/models/key.php
@@ -32,7 +32,7 @@ class SWJProjectsModelKey extends AdminModel
 		if ($item = parent::getItem($pk))
 		{
 			// Convert the projects field value to array
-			$item->projects = explode(',', $item->projects);
+			$item->projects = !empty($item->projects) ? explode(',', $item->projects) : [];
 
 			// Convert the params field value to array
 			$registry      = new Registry($item->plugins);

--- a/com_swjprojects/admin/models/project.php
+++ b/com_swjprojects/admin/models/project.php
@@ -53,7 +53,7 @@ class SWJProjectsModelProject extends AdminModel
 			$item->params = $registry->toArray();
 
 			// Convert the additional_categories field value to array
-			$item->additional_categories = explode(',', $item->additional_categories);
+			$item->additional_categories = !empty($item->additional_categories) ? explode(',', $item->additional_categories) : [];
 
 			// Default values
 			$item->translates = array();

--- a/com_swjprojects/admin/models/projects.php
+++ b/com_swjprojects/admin/models/projects.php
@@ -144,8 +144,8 @@ class SWJProjectsModelProjects extends ListModel
 		}
 
 		// Filter by download_type state
-		$download_type = trim($this->getState('filter.download_type'));
-		if (!empty($download_type))
+		$download_type = $this->getState('filter.download_type');
+		if (!empty($download_type) && !empty($download_type = trim($download_type)))
 		{
 			$query->where($db->quoteName('p.download_type') . ' = ' . $db->quote($download_type));
 		}


### PR DESCRIPTION
**Is your request related to issue**
Pull Request for Issue #99

**Summary of changes**
Check against empty string before performe trim() and explode().

**Testing Instructions**
Steps for testing:
1. Install extension with php version 8.1
2. Go to 'Admin/Projects' (ListView) or 'Admin/Project' (SingleItem) or 'Admin/Key' (SingleItem)
5. See result

**Expected result**
No more Deprecated: trim() and explode() messages

**Actual result**
No more Deprecated: trim() and explode() messages

**System Information (please complete the following information):**
 - Extensions version [1.6.2-dev]
 - PHP version: [8.1.12]